### PR TITLE
Fix go build "cannot write multiple packages to non-directory"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY go.sum go.mod ./
 RUN go mod download && go mod verify
 
 COPY . .
-RUN go build -v -o /usr/local/bin/app ./...
+RUN go build -v -o /usr/local/bin/app src/main.go
 
 EXPOSE 8080
 

--- a/src/main.go
+++ b/src/main.go
@@ -111,10 +111,16 @@ func main() {
 		slog.Error("Failed to load environment variables", "error", err)
 		os.Exit(1)
 	}
+	port, ok := os.LookupEnv("PORT")
+	if !ok {
+		slog.Error("PORT not found")
+		os.Exit(1)
+	}
+
 	http.HandleFunc("/", formHandler)
 	http.HandleFunc("/submit", submitHandler)
 	http.HandleFunc("/item", newItemHandler)
 
-	slog.Info("Server started on port 8080")
-	http.ListenAndServe(":8080", nil)
+	slog.Info("Server started", "port", port)
+	http.ListenAndServe(":"+port, nil)
 }


### PR DESCRIPTION
Also added PORT environment variable for Google Cloud continuous deployment.